### PR TITLE
Improvements for HTML5/XHTML specifications.

### DIFF
--- a/client/templates/stocks/stock_item.html
+++ b/client/templates/stocks/stock_item.html
@@ -5,7 +5,7 @@
  	<a href="http://www.gurufocus.com//stock.php?symbol={{ticker}}">{{ticker}} - GF </a> 
  	<li>{{buyFlag}}</li>
  </h3>
-      <br>
+      <br/>
       <table>
       	<tr>
       		<td>
@@ -16,7 +16,7 @@
             </td>
         </tr>
     </table>
-    <br>
+    <br/>
  </div>
  </div>
 </template>


### PR DESCRIPTION
**Introduction:**
In accordance with the w3 HTML5 specification for HTML code, void tags (see reference) should be marked as self-closing. During a scan for repositories containing HTML files, we found HTML code in your repository that needed this improvement.

Even though the self-closing specification is not a strict requirement by web-browsers, and they will happily parse the tag anyhow - that is not an excuse for not writing specification valid code, and I am more than happy to help correct this. In the spirit of an open-source community! The changes in this PullRequest will not break your code in any way.

**References:**
https://www.w3.org/TR/html5/syntax.html#void-elements
